### PR TITLE
fix(opencode): use correct SQLite column names (time_created/time_updated)

### DIFF
--- a/src/connectors/opencode.rs
+++ b/src/connectors/opencode.rs
@@ -97,7 +97,7 @@ impl OpenCodeConnector {
 
     /// Extract sessions from OpenCode's SQLite database (v1.2+).
     ///
-    /// Schema: session(id, title, directory, project_id, created_at, updated_at),
+    /// Schema: session(id, title, directory, project_id, time_created, time_updated),
     ///         message(id, session_id, data JSON), part(id, message_id, session_id, data JSON)
     fn extract_from_sqlite(
         db_path: &Path,
@@ -116,7 +116,7 @@ impl OpenCodeConnector {
         // We normalize in Rust rather than using strftime() which breaks on integer columns.
         let mut sessions: Vec<SqliteSession> = Vec::new();
         let mut stmt = conn.prepare(
-            "SELECT id, title, directory, project_id, created_at, updated_at FROM session"
+            "SELECT id, title, directory, project_id, time_created, time_updated FROM session"
         ).with_context(|| "failed to prepare session query")?;
 
         let row_fn = |row: &rusqlite::Row<'_>| -> rusqlite::Result<SqliteSession> {
@@ -212,10 +212,10 @@ impl OpenCodeConnector {
         conn: &Connection,
         session_id: &str,
     ) -> Result<Vec<NormalizedMessage>> {
-        // Query messages for this session. Read created_at as raw value since
+        // Query messages for this session. Read time_created as raw value since
         // Drizzle ORM may store it as TEXT or INTEGER.
         let mut stmt = conn.prepare(
-            "SELECT id, data, created_at FROM message WHERE session_id = ? ORDER BY created_at ASC"
+            "SELECT id, data, time_created FROM message WHERE session_id = ? ORDER BY time_created ASC"
         )?;
 
         let rows = stmt.query_map([session_id], |row| {
@@ -302,7 +302,7 @@ impl OpenCodeConnector {
     /// Load parts for a message from SQLite.
     fn load_parts_sqlite(conn: &Connection, message_id: &str) -> Result<Vec<PartInfo>> {
         let mut stmt = conn.prepare(
-            "SELECT data FROM part WHERE message_id = ? ORDER BY created_at ASC"
+            "SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC"
         )?;
 
         let rows = stmt.query_map([message_id], |row| {
@@ -2447,23 +2447,23 @@ mod tests {
                 project_id TEXT,
                 title TEXT,
                 directory TEXT,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+                time_created TEXT DEFAULT CURRENT_TIMESTAMP,
+                time_updated TEXT DEFAULT CURRENT_TIMESTAMP
             );
             CREATE TABLE message (
                 id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL,
                 data TEXT NOT NULL,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+                time_created TEXT DEFAULT CURRENT_TIMESTAMP,
+                time_updated TEXT DEFAULT CURRENT_TIMESTAMP
             );
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
                 message_id TEXT NOT NULL,
                 session_id TEXT NOT NULL,
                 data TEXT NOT NULL,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+                time_created TEXT DEFAULT CURRENT_TIMESTAMP,
+                time_updated TEXT DEFAULT CURRENT_TIMESTAMP
             );"
         ).unwrap();
 
@@ -2622,34 +2622,34 @@ mod tests {
                 project_id TEXT,
                 title TEXT,
                 directory TEXT,
-                created_at INTEGER,
-                updated_at INTEGER
+                time_created INTEGER,
+                time_updated INTEGER
             );
             CREATE TABLE message (
                 id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL,
                 data TEXT NOT NULL,
-                created_at INTEGER,
-                updated_at INTEGER
+                time_created INTEGER,
+                time_updated INTEGER
             );
             CREATE TABLE part (
                 id TEXT PRIMARY KEY,
                 message_id TEXT NOT NULL,
                 session_id TEXT NOT NULL,
                 data TEXT NOT NULL,
-                created_at INTEGER,
-                updated_at INTEGER
+                time_created INTEGER,
+                time_updated INTEGER
             );"
         ).unwrap();
 
         // Insert session with epoch second timestamps
         conn.execute(
-            "INSERT INTO session (id, project_id, title, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO session (id, project_id, title, time_created, time_updated) VALUES (?1, ?2, ?3, ?4, ?5)",
             rusqlite::params!["sess-int", "proj-1", "Integer TS Session", 1700000000_i64, 1700000100_i64],
         ).unwrap();
 
         conn.execute(
-            "INSERT INTO message (id, session_id, data, created_at) VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO message (id, session_id, data, time_created) VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params!["msg-int", "sess-int", r#"{"role":"user"}"#, 1700000050_i64],
         ).unwrap();
 


### PR DESCRIPTION
## Summary

- Fix OpenCode SQLite connector querying non-existent columns (`created_at`/`updated_at` → `time_created`/`time_updated`), which causes `failed to prepare session query` and silently falls back to flat-file scanning — making all post-v1.2 sessions invisible.

Fixes [Dicklesworthstone/coding_agent_session_search#91](https://github.com/Dicklesworthstone/coding_agent_session_search/issues/91). Related to [#84](https://github.com/Dicklesworthstone/coding_agent_session_search/issues/84).

## What changed

The OpenCode SQLite schema uses `time_created`/`time_updated` columns, but the connector was querying `created_at`/`updated_at`. This is a straightforward column rename in 3 SQL statements and 2 test schemas — no logic changes.

## Evidence

`RUST_LOG=debug cass index --full` on macOS with OpenCode v1.2+:
```
opencode sqlite: failed to read ~/.local/share/opencode/opencode.db: failed to prepare session query
```

The actual schema:
```sql
CREATE TABLE session (..., time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, ...);
CREATE TABLE message (..., time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, ...);
CREATE TABLE part    (..., time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, ...);
```