### PR TITLE
feat: add NormalizedInvocation for first-class tool/skill usage

### DIFF
--- a/src/connectors/aider.rs
+++ b/src/connectors/aider.rs
@@ -78,6 +78,7 @@ impl AiderConnector {
                         content: current_content.trim().to_string(),
                         extra: json!({}),
                         snippets: Vec::new(),
+                    invocations: Vec::new(),
                     });
                     msg_idx += 1;
                     current_content.clear();
@@ -103,6 +104,7 @@ impl AiderConnector {
                             content: current_content.trim().to_string(),
                             extra: json!({}),
                             snippets: Vec::new(),
+                    invocations: Vec::new(),
                         });
                         msg_idx += 1;
                         current_content.clear();
@@ -123,6 +125,7 @@ impl AiderConnector {
                 content: current_content.trim().to_string(),
                 extra: json!({}),
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 

--- a/src/connectors/amp.rs
+++ b/src/connectors/amp.rs
@@ -5,7 +5,10 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use super::scan::ScanContext;
-use super::{Connector, flatten_content, franken_detection_for_connector, parse_timestamp};
+use super::{
+    Connector, extract_invocations_from_content_blocks, flatten_content,
+    franken_detection_for_connector, parse_timestamp, unwrap_skill_invocations,
+};
 use crate::types::{DetectionResult, NormalizedConversation, NormalizedMessage};
 
 pub struct AmpConnector;
@@ -261,6 +264,13 @@ fn extract_messages(val: &Value, _since_ts: Option<i64>) -> Option<Vec<Normalize
             created_at,
             content,
             extra: m.clone(),
+            invocations: {
+                let mut inv = m
+                    .get("content")
+                    .map_or_else(Vec::new, extract_invocations_from_content_blocks);
+                unwrap_skill_invocations(&mut inv);
+                inv
+            },
             snippets: Vec::new(),
         });
     }

--- a/src/connectors/chatgpt.rs
+++ b/src/connectors/chatgpt.rs
@@ -394,6 +394,7 @@ impl ChatGptConnector {
                     content: content_str,
                     extra: msg.clone(),
                     snippets: Vec::new(),
+                    invocations: Vec::new(),
                 });
             }
         }
@@ -446,6 +447,7 @@ impl ChatGptConnector {
                     content: content.to_string(),
                     extra: item.clone(),
                     snippets: Vec::new(),
+                    invocations: Vec::new(),
                 });
             }
         }

--- a/src/connectors/claude_code.rs
+++ b/src/connectors/claude_code.rs
@@ -7,8 +7,8 @@ use walkdir::WalkDir;
 
 use super::scan::ScanContext;
 use super::{
-    Connector, file_modified_since, flatten_content, franken_detection_for_connector,
-    parse_timestamp,
+    Connector, extract_invocations_from_content_blocks, file_modified_since, flatten_content,
+    franken_detection_for_connector, parse_timestamp,
 };
 use crate::types::{DetectionResult, NormalizedConversation, NormalizedMessage};
 
@@ -304,6 +304,8 @@ fn scan_claude_with_callback(
                         .and_then(|m| m.get("model"))
                         .and_then(|v| v.as_str())
                         .map(String::from);
+                    let invocations = content_val
+                        .map_or_else(Vec::new, extract_invocations_from_content_blocks);
 
                     messages.push(NormalizedMessage {
                         idx: 0,
@@ -316,6 +318,7 @@ fn scan_claude_with_callback(
                         } else {
                             val
                         },
+                        invocations,
                         snippets: Vec::new(),
                     });
                 }
@@ -378,6 +381,9 @@ fn scan_claude_with_callback(
                             continue;
                         }
 
+                        let content_val = item
+                            .get("content")
+                            .or_else(|| item.get("text"));
                         messages.push(NormalizedMessage {
                             idx: 0,
                             role: role.to_string(),
@@ -389,6 +395,8 @@ fn scan_claude_with_callback(
                             } else {
                                 item.clone()
                             },
+                            invocations: content_val
+                                .map_or_else(Vec::new, extract_invocations_from_content_blocks),
                             snippets: Vec::new(),
                         });
                     }

--- a/src/connectors/clawdbot.rs
+++ b/src/connectors/clawdbot.rs
@@ -186,6 +186,7 @@ impl Connector for ClawdbotConnector {
                         content,
                         extra: val,
                         snippets: Vec::new(),
+                    invocations: Vec::new(),
                     });
                 }
 

--- a/src/connectors/cline.rs
+++ b/src/connectors/cline.rs
@@ -6,8 +6,8 @@ use serde_json::Value;
 
 use super::scan::ScanContext;
 use super::{
-    Connector, file_modified_since, flatten_content, franken_detection_for_connector,
-    parse_timestamp,
+    Connector, extract_invocations_from_content_blocks, file_modified_since, flatten_content,
+    franken_detection_for_connector, parse_timestamp,
 };
 use crate::types::{DetectionResult, NormalizedConversation, NormalizedMessage};
 
@@ -216,6 +216,10 @@ impl Connector for ClineConnector {
                             continue;
                         }
 
+                        let content_val = item
+                            .get("content")
+                            .or_else(|| item.get("text"))
+                            .or_else(|| item.get("message"));
                         messages.push(NormalizedMessage {
                             idx: i64::try_from(messages.len()).unwrap_or(i64::MAX), // preserve original order for stable sorting
                             role: role.to_string(),
@@ -223,6 +227,8 @@ impl Connector for ClineConnector {
                             created_at: created,
                             content,
                             extra: item.clone(),
+                            invocations: content_val
+                                .map_or_else(Vec::new, extract_invocations_from_content_blocks),
                             snippets: Vec::new(),
                         });
                     }

--- a/src/connectors/codex.rs
+++ b/src/connectors/codex.rs
@@ -7,8 +7,8 @@ use walkdir::WalkDir;
 
 use super::scan::ScanContext;
 use super::{
-    Connector, file_modified_since, flatten_content, franken_detection_for_connector,
-    parse_timestamp,
+    Connector, extract_invocations_from_content_blocks, file_modified_since, flatten_content,
+    franken_detection_for_connector, parse_timestamp,
 };
 use crate::types::{DetectionResult, NormalizedConversation, NormalizedMessage};
 
@@ -320,6 +320,9 @@ fn scan_codex_with_callback(
                                 }
 
                                 update_time_bounds(&mut started_at, &mut ended_at, created);
+                                let invocations = payload
+                                    .get("content")
+                                    .map_or_else(Vec::new, extract_invocations_from_content_blocks);
 
                                 messages.push(NormalizedMessage {
                                     idx: 0,
@@ -332,6 +335,7 @@ fn scan_codex_with_callback(
                                     } else {
                                         val
                                     },
+                                    invocations,
                                     snippets: Vec::new(),
                                 });
                             }
@@ -363,6 +367,7 @@ fn scan_codex_with_callback(
                                                 } else {
                                                     val
                                                 },
+                                                invocations: Vec::new(),
                                                 snippets: Vec::new(),
                                             });
                                         }
@@ -389,6 +394,7 @@ fn scan_codex_with_callback(
                                                 } else {
                                                     val
                                                 },
+                                                invocations: Vec::new(),
                                                 snippets: Vec::new(),
                                             });
                                         }
@@ -457,6 +463,9 @@ fn scan_codex_with_callback(
                             } else {
                                 item.clone()
                             },
+                            invocations: item
+                                .get("content")
+                                .map_or_else(Vec::new, extract_invocations_from_content_blocks),
                             snippets: Vec::new(),
                         });
                     }

--- a/src/connectors/copilot.rs
+++ b/src/connectors/copilot.rs
@@ -305,6 +305,7 @@ impl CopilotConnector {
                             content,
                             extra: request.clone(),
                             snippets: Vec::new(),
+                    invocations: Vec::new(),
                         });
                     }
                 }
@@ -332,6 +333,7 @@ impl CopilotConnector {
                             content,
                             extra: response.clone(),
                             snippets: Vec::new(),
+                    invocations: Vec::new(),
                         });
                     }
                 }
@@ -378,6 +380,7 @@ impl CopilotConnector {
                     content,
                     extra: msg.clone(),
                     snippets: Vec::new(),
+                    invocations: Vec::new(),
                 });
             }
         }
@@ -561,6 +564,7 @@ impl CopilotConnector {
                 content,
                 extra: event,
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 
@@ -681,6 +685,7 @@ impl CopilotConnector {
                 content,
                 extra: event.clone(),
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 

--- a/src/connectors/copilot_cli.rs
+++ b/src/connectors/copilot_cli.rs
@@ -220,6 +220,7 @@ impl CopilotCliConnector {
                 content,
                 extra: event,
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 
@@ -331,6 +332,7 @@ impl CopilotCliConnector {
                 content,
                 extra: event.clone(),
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 

--- a/src/connectors/crush.rs
+++ b/src/connectors/crush.rs
@@ -251,6 +251,7 @@ fn group_rows_into_conversations(rows: &[CrushRow], db_path: &Path) -> Vec<Norma
                 "provider": row.provider,
             }),
             snippets: Vec::new(),
+                    invocations: Vec::new(),
         });
 
         if current_session_id != Some(&row.session_id) {

--- a/src/connectors/cursor.rs
+++ b/src/connectors/cursor.rs
@@ -517,6 +517,7 @@ impl CursorConnector {
                 content: user_text.to_string(),
                 extra: serde_json::json!({}),
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 
@@ -659,6 +660,7 @@ impl CursorConnector {
             content: content.to_string(),
             extra: bubble.clone(),
             snippets: Vec::new(),
+                    invocations: Vec::new(),
         })
     }
 

--- a/src/connectors/factory.rs
+++ b/src/connectors/factory.rs
@@ -20,8 +20,8 @@ use walkdir::WalkDir;
 
 use super::scan::ScanContext;
 use super::{
-    Connector, file_modified_since, flatten_content, franken_detection_for_connector,
-    parse_timestamp,
+    Connector, extract_invocations_from_content_blocks, file_modified_since, flatten_content,
+    franken_detection_for_connector, parse_timestamp,
 };
 use crate::types::{DetectionResult, NormalizedConversation, NormalizedMessage};
 
@@ -224,6 +224,8 @@ fn parse_factory_session(path: &Path) -> Result<Option<NormalizedConversation>> 
                     .and_then(|v| v.as_str())
                     .map(String::from);
 
+                let invocations = content_val
+                    .map_or_else(Vec::new, extract_invocations_from_content_blocks);
                 messages.push(NormalizedMessage {
                     idx: 0, // Will be reassigned after collection
                     role: role.to_string(),
@@ -231,6 +233,7 @@ fn parse_factory_session(path: &Path) -> Result<Option<NormalizedConversation>> 
                     created_at: created,
                     content: content_str,
                     extra: val,
+                    invocations,
                     snippets: Vec::new(),
                 });
             }

--- a/src/connectors/gemini.rs
+++ b/src/connectors/gemini.rs
@@ -387,6 +387,7 @@ fn scan_gemini_with_callback(
                     item
                 },
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             });
         }
 
@@ -609,6 +610,7 @@ mod tests {
             content: "# AGENTS.md instructions for /data/projects/myapp\nHello".into(),
             extra: serde_json::Value::Null,
             snippets: vec![],
+            invocations: vec![],
         }];
         let result = extract_workspace_from_content(&messages);
         assert_eq!(result, Some(PathBuf::from("/data/projects/myapp")));
@@ -624,6 +626,7 @@ mod tests {
             content: "Working directory: /home/user/project\nLet me help.".into(),
             extra: serde_json::Value::Null,
             snippets: vec![],
+            invocations: vec![],
         }];
         let result = extract_workspace_from_content(&messages);
         assert_eq!(result, Some(PathBuf::from("/home/user/project")));
@@ -639,6 +642,7 @@ mod tests {
             content: "Check the file at /data/projects/foo/src/main.rs".into(),
             extra: serde_json::Value::Null,
             snippets: vec![],
+            invocations: vec![],
         }];
         let result = extract_workspace_from_content(&messages);
         assert_eq!(result, Some(PathBuf::from("/data/projects/foo")));
@@ -654,6 +658,7 @@ mod tests {
             content: "Hello, how are you?".into(),
             extra: serde_json::Value::Null,
             snippets: vec![],
+            invocations: vec![],
         }];
         let result = extract_workspace_from_content(&messages);
         assert_eq!(result, None);
@@ -671,6 +676,7 @@ mod tests {
                     .into(),
             extra: serde_json::Value::Null,
             snippets: vec![],
+            invocations: vec![],
         }];
         // AGENTS.md pattern should be found first
         let result = extract_workspace_from_content(&messages);

--- a/src/connectors/kimi.rs
+++ b/src/connectors/kimi.rs
@@ -314,46 +314,70 @@ fn parse_kimi_session(path: &Path) -> Result<Option<NormalizedConversation>> {
                             content,
                             extra: val.clone(),
                             snippets: Vec::new(),
+                            invocations: Vec::new(),
                         });
-                    }
-                }
+                        }
+                        }
 
-                // After a user TurnBegin, subsequent ContentParts are assistant responses
-                if is_user {
-                    current_role = "assistant".to_string();
-                }
-            }
-            (Some("ContentPart"), _) => {
-                let payload = msg.and_then(|m| m.get("payload"));
-                let content = payload.map(extract_content_part_text).unwrap_or_default();
+                        // After a user TurnBegin, subsequent ContentParts are assistant responses
+                        if is_user {
+                        current_role = "assistant".to_string();
+                        }
+                        }
+                        (Some("ContentPart"), _) => {
+                        let payload = msg.and_then(|m| m.get("payload"));
+                        let content = payload.map(extract_content_part_text).unwrap_or_default();
 
-                if !content.trim().is_empty() {
-                    messages.push(NormalizedMessage {
+                        if !content.trim().is_empty() {
+                        messages.push(NormalizedMessage {
+                            idx: 0,
+                            role: current_role.clone(),
+                            author: None,
+                            created_at: created,
+                            content,
+                            extra: val,
+                            snippets: Vec::new(),
+                            invocations: Vec::new(),
+                        });
+                        }
+                        }
+                        (Some("ToolCall"), _) => {
+                        let payload = msg.and_then(|m| m.get("payload"));
+                        let content = payload
+                        .map(extract_tool_call_text)
+                        .unwrap_or_else(|| "[Tool: unknown]".to_string());
+
+                        let invocations = if let Some(p) = payload {
+                        let tool_name = p
+                            .get("name")
+                            .or_else(|| p.get("toolName"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown");
+                        vec![crate::types::NormalizedInvocation {
+                            kind: "tool".to_string(),
+                            name: tool_name.to_string(),
+                            raw_name: None,
+                            call_id: None,
+                            arguments: p
+                                .get("input")
+                                .or_else(|| p.get("arguments"))
+                                .or_else(|| p.get("parameters"))
+                                .cloned(),
+                        }]
+                        } else {
+                        Vec::new()
+                        };
+
+                        messages.push(NormalizedMessage {
                         idx: 0,
-                        role: current_role.clone(),
+                        role: "assistant".to_string(),
                         author: None,
                         created_at: created,
                         content,
                         extra: val,
                         snippets: Vec::new(),
-                    });
-                }
-            }
-            (Some("ToolCall"), _) => {
-                let payload = msg.and_then(|m| m.get("payload"));
-                let content = payload
-                    .map(extract_tool_call_text)
-                    .unwrap_or_else(|| "[Tool: unknown]".to_string());
-
-                messages.push(NormalizedMessage {
-                    idx: 0,
-                    role: "assistant".to_string(),
-                    author: None,
-                    created_at: created,
-                    content,
-                    extra: val,
-                    snippets: Vec::new(),
-                });
+                        invocations,
+                        });
             }
             // Skip metadata, StepBegin, and other non-content types
             _ => {}

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -37,7 +37,10 @@ pub use token_extraction::{
     ExtractedTokenUsage, ModelInfo, TokenDataSource, estimate_tokens_from_content,
     extract_claude_code_tokens, extract_codex_tokens, extract_tokens_for_agent, normalize_model,
 };
-pub use utils::{file_modified_since, flatten_content, parse_timestamp};
+pub use utils::{
+    extract_invocations_from_content_blocks, file_modified_since, flatten_content, parse_timestamp,
+    unwrap_skill_invocations,
+};
 pub use workspace_cache::WorkspaceCache;
 
 use std::path::PathBuf;

--- a/src/connectors/openclaw.rs
+++ b/src/connectors/openclaw.rs
@@ -432,6 +432,39 @@ impl Connector for OpenClawConnector {
                                 (other, None) => other,
                             };
 
+                            let invocations = msg
+                                .get("content")
+                                .and_then(|c| c.as_array())
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter(|block| {
+                                            block.get("type").and_then(|t| t.as_str())
+                                                == Some("toolCall")
+                                        })
+                                        .map(|block| {
+                                            let name = block
+                                                .get("name")
+                                                .and_then(|n| n.as_str())
+                                                .unwrap_or("unknown")
+                                                .to_string();
+                                            crate::types::NormalizedInvocation {
+                                                kind: "tool".to_string(),
+                                                name,
+                                                raw_name: None,
+                                                call_id: block
+                                                    .get("id")
+                                                    .and_then(|v| v.as_str())
+                                                    .map(String::from),
+                                                arguments: block
+                                                    .get("arguments")
+                                                    .or_else(|| block.get("input"))
+                                                    .cloned(),
+                                            }
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default();
+
                             let idx = i64::try_from(messages.len()).unwrap_or(i64::MAX);
                             messages.push(NormalizedMessage {
                                 idx,
@@ -441,6 +474,7 @@ impl Connector for OpenClawConnector {
                                 content,
                                 extra: val,
                                 snippets: Vec::new(),
+                                invocations,
                             });
                         }
                         // Skip model_change, thinking_level_change, custom, etc.

--- a/src/connectors/opencode.rs
+++ b/src/connectors/opencode.rs
@@ -283,6 +283,7 @@ impl OpenCodeConnector {
                         "session_id": session_id,
                     }),
                     snippets: Vec::new(),
+                    invocations: Vec::new(),
                 },
             ));
         }
@@ -837,6 +838,7 @@ fn load_messages(session_msg_dir: &Path, part_dir: &Path) -> Result<Vec<Normaliz
                     "session_id": msg_info.session_id,
                 }),
                 snippets: Vec::new(),
+                    invocations: Vec::new(),
             },
         ));
     }

--- a/src/connectors/pi_agent.rs
+++ b/src/connectors/pi_agent.rs
@@ -309,6 +309,36 @@ impl Connector for PiAgentConnector {
                                 None
                             };
 
+                            let invocations = msg
+                                .get("content")
+                                .and_then(|c| c.as_array())
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter(|item| {
+                                            item.get("type").and_then(|t| t.as_str())
+                                                == Some("toolCall")
+                                        })
+                                        .map(|item| {
+                                            let name = item
+                                                .get("name")
+                                                .and_then(|n| n.as_str())
+                                                .unwrap_or("unknown")
+                                                .to_string();
+                                            crate::types::NormalizedInvocation {
+                                                kind: "tool".to_string(),
+                                                name,
+                                                raw_name: None,
+                                                call_id: item
+                                                    .get("id")
+                                                    .and_then(|v| v.as_str())
+                                                    .map(String::from),
+                                                arguments: item.get("arguments").cloned(),
+                                            }
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default();
+
                             messages.push(NormalizedMessage {
                                 idx: i64::try_from(messages.len()).unwrap_or(i64::MAX),
                                 role: normalized_role.to_string(),
@@ -317,6 +347,7 @@ impl Connector for PiAgentConnector {
                                 content: content_str,
                                 extra: val.clone(),
                                 snippets: Vec::new(),
+                                invocations,
                             });
                         }
                     }

--- a/src/connectors/qwen.rs
+++ b/src/connectors/qwen.rs
@@ -192,6 +192,7 @@ fn parse_qwen_session(path: &Path) -> Result<Option<NormalizedConversation>> {
             content: content_str,
             extra: raw_msg.clone(),
             snippets: Vec::new(),
+                    invocations: Vec::new(),
         });
     }
 

--- a/src/connectors/utils.rs
+++ b/src/connectors/utils.rs
@@ -144,6 +144,83 @@ fn extract_content_part(item: &serde_json::Value) -> Option<String> {
     None
 }
 
+/// Extract structured invocations from a Claude API-style content block array.
+///
+/// Emits every `tool_use` block as `kind: "tool"`. Connector-specific
+/// unwrapping (e.g. Amp's skill wrapper) should be applied separately via
+/// [`unwrap_skill_invocations`].
+///
+/// Works for any connector that stores content as an array of typed blocks:
+/// amp, claude_code, codex, cline, factory.
+#[must_use]
+pub fn extract_invocations_from_content_blocks(
+    val: &serde_json::Value,
+) -> Vec<crate::types::NormalizedInvocation> {
+    let Some(arr) = val.as_array() else {
+        return Vec::new();
+    };
+
+    let mut invocations = Vec::new();
+    for item in arr {
+        let item_type = item.get("type").and_then(|v| v.as_str());
+        if item_type != Some("tool_use") {
+            continue;
+        }
+
+        let Some(raw_name) = item.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let call_id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(std::string::ToString::to_string);
+        let input = item.get("input");
+
+        invocations.push(crate::types::NormalizedInvocation {
+            kind: "tool".to_string(),
+            name: raw_name.to_string(),
+            raw_name: None,
+            call_id,
+            arguments: input.cloned(),
+        });
+    }
+
+    invocations
+}
+
+/// Amp-specific wrapper tools that should be unwrapped to their inner name.
+const AMP_SKILL_WRAPPERS: &[(&str, &str)] = &[
+    // (tool_name, input_key_for_real_name)
+    ("skill", "name"),
+    ("load_skill", "name"),
+];
+
+/// Unwrap Amp skill-wrapper invocations in place.
+///
+/// Tools like `skill` and `load_skill` are Amp-specific wrappers whose real
+/// name lives inside the `input` object. This rewrites matching invocations
+/// to `kind: "skill"` with the inner name, preserving `raw_name` for
+/// traceability. Non-matching invocations are left unchanged.
+pub fn unwrap_skill_invocations(invocations: &mut Vec<crate::types::NormalizedInvocation>) {
+    for inv in invocations.iter_mut() {
+        if let Some((_, key)) = AMP_SKILL_WRAPPERS
+            .iter()
+            .find(|(name, _)| *name == inv.name)
+        {
+            if let Some(inner_name) = inv
+                .arguments
+                .as_ref()
+                .and_then(|a| a.get(*key))
+                .and_then(|v| v.as_str())
+            {
+                inv.raw_name = Some(inv.name.clone());
+                inv.name = inner_name.to_string();
+                inv.kind = "skill".to_string();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -310,5 +387,157 @@ mod tests {
     fn flatten_content_whitespace_only() {
         let val = json!("   ");
         assert_eq!(flatten_content(&val), "   ");
+    }
+
+    // --- extract_invocations_from_content_blocks tests ---
+
+    #[test]
+    fn extract_invocations_plain_tool_use() {
+        let val = json!([
+            {"type": "text", "text": "Let me read that file."},
+            {"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {"path": "/src/main.rs"}}
+        ]);
+        let invocations = extract_invocations_from_content_blocks(&val);
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].kind, "tool");
+        assert_eq!(invocations[0].name, "Read");
+        assert!(invocations[0].raw_name.is_none());
+        assert_eq!(invocations[0].call_id.as_deref(), Some("toolu_1"));
+        assert_eq!(invocations[0].arguments.as_ref().unwrap()["path"], "/src/main.rs");
+    }
+
+    #[test]
+    fn extract_invocations_skill_not_unwrapped_by_shared_helper() {
+        // The shared helper should NOT unwrap skill wrappers — that's Amp-specific.
+        let val = json!([
+            {"type": "tool_use", "id": "toolu_2", "name": "skill", "input": {"name": "github-prs"}}
+        ]);
+        let invocations = extract_invocations_from_content_blocks(&val);
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].kind, "tool");
+        assert_eq!(invocations[0].name, "skill");
+        assert!(invocations[0].raw_name.is_none());
+    }
+
+    #[test]
+    fn extract_invocations_skill_without_inner_name_falls_back() {
+        let val = json!([
+            {"type": "tool_use", "name": "skill", "input": {"arguments": "something"}}
+        ]);
+        let invocations = extract_invocations_from_content_blocks(&val);
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].kind, "tool");
+        assert_eq!(invocations[0].name, "skill");
+        assert!(invocations[0].raw_name.is_none());
+    }
+
+    #[test]
+    fn extract_invocations_multiple_tools() {
+        let val = json!([
+            {"type": "tool_use", "name": "Read", "input": {"path": "a.rs"}},
+            {"type": "text", "text": "Now editing..."},
+            {"type": "tool_use", "name": "edit_file", "input": {"path": "a.rs", "old_str": "x", "new_str": "y"}},
+            {"type": "tool_use", "name": "skill", "input": {"name": "git"}}
+        ]);
+        let invocations = extract_invocations_from_content_blocks(&val);
+        assert_eq!(invocations.len(), 3);
+        assert_eq!(invocations[0].name, "Read");
+        assert_eq!(invocations[0].kind, "tool");
+        assert_eq!(invocations[1].name, "edit_file");
+        assert_eq!(invocations[1].kind, "tool");
+        // Shared helper does NOT unwrap skill — emits as plain tool
+        assert_eq!(invocations[2].name, "skill");
+        assert_eq!(invocations[2].kind, "tool");
+    }
+
+    // --- unwrap_skill_invocations tests ---
+
+    #[test]
+    fn unwrap_skill_invocations_rewrites_skill_wrapper() {
+        let mut invocations = vec![crate::types::NormalizedInvocation {
+            kind: "tool".to_string(),
+            name: "skill".to_string(),
+            raw_name: None,
+            call_id: Some("toolu_1".to_string()),
+            arguments: Some(json!({"name": "github-prs"})),
+        }];
+        unwrap_skill_invocations(&mut invocations);
+        assert_eq!(invocations[0].kind, "skill");
+        assert_eq!(invocations[0].name, "github-prs");
+        assert_eq!(invocations[0].raw_name.as_deref(), Some("skill"));
+    }
+
+    #[test]
+    fn unwrap_skill_invocations_rewrites_load_skill_wrapper() {
+        let mut invocations = vec![crate::types::NormalizedInvocation {
+            kind: "tool".to_string(),
+            name: "load_skill".to_string(),
+            raw_name: None,
+            call_id: None,
+            arguments: Some(json!({"name": "git"})),
+        }];
+        unwrap_skill_invocations(&mut invocations);
+        assert_eq!(invocations[0].kind, "skill");
+        assert_eq!(invocations[0].name, "git");
+        assert_eq!(invocations[0].raw_name.as_deref(), Some("load_skill"));
+    }
+
+    #[test]
+    fn unwrap_skill_invocations_leaves_non_wrappers_unchanged() {
+        let mut invocations = vec![crate::types::NormalizedInvocation {
+            kind: "tool".to_string(),
+            name: "Read".to_string(),
+            raw_name: None,
+            call_id: None,
+            arguments: Some(json!({"path": "/src/main.rs"})),
+        }];
+        unwrap_skill_invocations(&mut invocations);
+        assert_eq!(invocations[0].kind, "tool");
+        assert_eq!(invocations[0].name, "Read");
+        assert!(invocations[0].raw_name.is_none());
+    }
+
+    #[test]
+    fn unwrap_skill_invocations_no_inner_name_leaves_unchanged() {
+        let mut invocations = vec![crate::types::NormalizedInvocation {
+            kind: "tool".to_string(),
+            name: "skill".to_string(),
+            raw_name: None,
+            call_id: None,
+            arguments: Some(json!({"arguments": "something"})),
+        }];
+        unwrap_skill_invocations(&mut invocations);
+        // No "name" key in arguments — should remain as tool "skill"
+        assert_eq!(invocations[0].kind, "tool");
+        assert_eq!(invocations[0].name, "skill");
+        assert!(invocations[0].raw_name.is_none());
+    }
+
+    #[test]
+    fn extract_invocations_no_tool_use_blocks() {
+        let val = json!([
+            {"type": "text", "text": "Just plain text."}
+        ]);
+        assert!(extract_invocations_from_content_blocks(&val).is_empty());
+    }
+
+    #[test]
+    fn extract_invocations_string_content_returns_empty() {
+        let val = json!("plain string");
+        assert!(extract_invocations_from_content_blocks(&val).is_empty());
+    }
+
+    #[test]
+    fn extract_invocations_null_returns_empty() {
+        let val = json!(null);
+        assert!(extract_invocations_from_content_blocks(&val).is_empty());
+    }
+
+    #[test]
+    fn extract_invocations_tool_use_missing_name_skipped() {
+        let val = json!([
+            {"type": "tool_use", "input": {"path": "a.rs"}}
+        ]);
+        assert!(extract_invocations_from_content_blocks(&val).is_empty());
     }
 }

--- a/src/connectors/vibe.rs
+++ b/src/connectors/vibe.rs
@@ -228,6 +228,7 @@ impl Connector for VibeConnector {
                         content,
                         extra: val,
                         snippets: Vec::new(),
+                    invocations: Vec::new(),
                     });
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use types::{
     // Scan & provenance types
     LOCAL_SOURCE_ID,
     NormalizedConversation,
+    NormalizedInvocation,
     NormalizedMessage,
     NormalizedSnippet,
     Origin,
@@ -48,7 +49,8 @@ pub use connectors::{
     cline::ClineConnector, codex::CodexConnector, copilot::CopilotConnector,
     copilot_cli::CopilotCliConnector, estimate_tokens_from_content, extract_claude_code_tokens,
     extract_codex_tokens, extract_tokens_for_agent, factory::FactoryConnector, file_modified_since,
-    flatten_content, franken_detection_for_connector, gemini::GeminiConnector,
+    extract_invocations_from_content_blocks, flatten_content,
+    franken_detection_for_connector, gemini::GeminiConnector,
     get_connector_factories, kimi::KimiConnector, normalize_model, openclaw::OpenClawConnector,
     parse_timestamp, pi_agent::PiAgentConnector, qwen::QwenConnector, token_extraction,
     vibe::VibeConnector,

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,6 +50,31 @@ pub struct NormalizedMessage {
     pub content: String,
     pub extra: serde_json::Value,
     pub snippets: Vec<NormalizedSnippet>,
+    /// Structured tool/skill invocations extracted from this message.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invocations: Vec<NormalizedInvocation>,
+}
+
+/// A single tool or skill invocation within a message.
+#[cfg(feature = "connectors")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NormalizedInvocation {
+    /// Classification: `"tool"` or `"skill"`.
+    pub kind: String,
+    /// Canonical searchable name (e.g. `"github-prs"`, `"Read"`, `"bash"`).
+    /// For wrapper tools like Amp's `skill("github-prs")`, this is the
+    /// unwrapped semantic name, not `"skill"`.
+    pub name: String,
+    /// Original tool name when different from `name` (e.g. `"skill"` for
+    /// Amp skill wrapper calls).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_name: Option<String>,
+    /// Provider-assigned call ID, useful for joining with tool results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
+    /// Raw input/arguments passed to the tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<serde_json::Value>,
 }
 
 #[cfg(feature = "connectors")]


### PR DESCRIPTION
_This PR description was generated by Amp._ 🤖

Adds `NormalizedInvocation` to make tool/skill usage directly queryable across agents, without parsing raw JSON from `extra`. Closes #2.

## Changes

**New type** — `NormalizedInvocation { kind, name, raw_name, call_id, arguments }` added to `NormalizedMessage` with `serde(default)` + `skip_serializing_if` for backwards compatibility.

**Shared helper** — `extract_invocations_from_content_blocks()` extracts `tool_use` blocks from Claude API-style content arrays as `kind: "tool"`. Used by amp, claude_code, codex, cline, factory.

**Amp skill unwrapping** — Separate `unwrap_skill_invocations()` function rewrites Amp-specific `skill`/`load_skill` wrappers to `kind: "skill"` with the inner name. Only called from `amp.rs`.

**Connector-specific extraction** — Kimi (`ToolCall` payload, multi-field argument lookup), OpenClaw (`toolCall` blocks, `arguments`-first field), pi_agent, and Codex JSONL `event_msg/tool_call` events each have custom extraction matching their stored formats.

**Remaining connectors** — `Vec::new()` where no structured tool call data exists in stored format (gemini, cursor, copilot, copilot_cli, aider, opencode, qwen, vibe, clawdbot, chatgpt, crush).
