### PR TITLE
feat(connectors): re-export HermesConnector at crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub use connectors::crush::CrushConnector;
 pub use connectors::cursor::CursorConnector;
 #[cfg(feature = "goose")]
 pub use connectors::goose::GooseConnector;
+#[cfg(feature = "hermes")]
+pub use connectors::hermes::HermesConnector;
 #[cfg(feature = "opencode")]
 pub use connectors::opencode::OpenCodeConnector;
 #[cfg(feature = "connectors")]


### PR DESCRIPTION
## Summary

Other gated connectors (`chatgpt`, `crush`, `cursor`, `goose`, `opencode`) are re-exported at the crate root behind their feature flag. `HermesConnector` was the only one missing — it's only reachable via `connectors::hermes::HermesConnector`, which prevents downstream crates from using the same import pattern as every other connector.

This is a 2-line fix to make the `hermes` feature behave like its peers.

## Diff

```rust
 #[cfg(feature = "goose")]
 pub use connectors::goose::GooseConnector;
+#[cfg(feature = "hermes")]
+pub use connectors::hermes::HermesConnector;
 #[cfg(feature = "opencode")]
 pub use connectors::opencode::OpenCodeConnector;
```

## Why now

I'm preparing a companion PR on `coding_agent_session_search` to enable the `hermes` feature there (it was added in #5 but never wired into CASS's feature set). The CASS connector follows the convention of `pub use franken_agent_detection::FooConnector;` — without this re-export, that import path doesn't resolve.

## Verification

- Schema match against a live `~/.hermes/state.db` (763 sessions, 5644 messages) — `sessions`/`messages` tables match the connector's expectations exactly.
- No behavior change for any consumer that doesn't enable the `hermes` feature.