### PR TITLE
Skip NULL-value rows in Cursor connector queries

### DIFF
--- a/src/connectors/cursor.rs
+++ b/src/connectors/cursor.rs
@@ -450,7 +450,7 @@ impl CursorConnector {
         let composer_prefix = "composerData:";
         let composer_limit = Self::prefix_upper_bound(composer_prefix);
         if let Ok(rows) = conn.query_map_collect(
-            "SELECT key, value FROM cursorDiskKV WHERE key >= ? AND key < ?",
+            "SELECT key, value FROM cursorDiskKV WHERE key >= ? AND key < ? AND value IS NOT NULL",
             params![composer_prefix, composer_limit.as_str()],
             |row| {
                 let key: String = row.get_typed(0)?;
@@ -474,7 +474,7 @@ impl CursorConnector {
 
         // Also try ItemTable for legacy aichat data
         if let Ok(rows) = conn.query_map_collect(
-            "SELECT key, value FROM ItemTable WHERE key LIKE '%aichat%chatdata%' OR key LIKE '%composer%'",
+            "SELECT key, value FROM ItemTable WHERE (key LIKE '%aichat%chatdata%' OR key LIKE '%composer%') AND value IS NOT NULL",
             params![],
             |row| {
                 let key: String = row.get_typed(0)?;
@@ -1584,6 +1584,36 @@ mod tests {
 
         let result = CursorConnector::extract_from_db(&db_path, None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_from_db_skips_rows_with_null_value() {
+        // Cursor stores some rows in cursorDiskKV / ItemTable with a NULL value
+        // (e.g. internal markers without payload). The row mapper requests
+        // `value` as `String`, so a single NULL row used to abort the entire
+        // `query_map_collect` via fail-fast semantics, silently dropping every
+        // valid composerData row alongside it.
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("state.vscdb");
+
+        let conn = create_test_db(&db_path);
+        let value = json!({ "text": "real conversation" }).to_string();
+        conn.execute_compat(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)",
+            params!["composerData:real-1", value.as_str()],
+        )
+        .unwrap();
+        // NULL-value row that previously poisoned the whole query.
+        conn.execute_compat(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?, NULL)",
+            params!["composerData:null-marker"],
+        )
+        .unwrap();
+        drop(conn);
+
+        let convs = CursorConnector::extract_from_db(&db_path, None).unwrap();
+        assert_eq!(convs.len(), 1);
+        assert!(convs[0].messages[0].content.contains("real conversation"));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Cursor stores some rows in `cursorDiskKV` and `ItemTable` with a NULL `value` (looks like internal markers / tombstones without payload). The row mapper inside `extract_from_db` requests `value` as `String`:

```rust
let value: String = row.get_typed(1)?;
```

so a single NULL row aborts the entire `query_map_collect` via fail-fast row-iterator semantics. Since the call site wraps the result in `if let Ok(rows) = ...`, the error is also invisible — the rows just silently disappear.

## Symptom

On my macOS box (`~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`, Cursor v0.40+ schema, ~75 valid `composerData:` rows plus exactly one NULL-value marker), the cursor connector reported `discovered=true scan_ms=0` and indexed **zero** conversations. `cass stats` showed `cursor: 0` while every other detected connector worked normally. Reproduced the same behavior on all seven `workspaceStorage/*/state.vscdb` files that had any matching keys.

After filtering NULL values at the SQL level, `cass stats` jumps to `cursor: 32` on the same box and `cass search` happily returns Cursor sessions.

## Change

Two additions to existing SQL strings inside `CursorConnector::extract_from_db`:

```diff
- "SELECT key, value FROM cursorDiskKV WHERE key >= ? AND key < ?"
+ "SELECT key, value FROM cursorDiskKV WHERE key >= ? AND key < ? AND value IS NOT NULL"

- "SELECT key, value FROM ItemTable WHERE key LIKE '%aichat%chatdata%' OR key LIKE '%composer%'"
+ "SELECT key, value FROM ItemTable WHERE (key LIKE '%aichat%chatdata%' OR key LIKE '%composer%') AND value IS NOT NULL"
```

NULL-value rows carry no extractable chat content anyway, so dropping them at the SQL layer is strictly a noise filter — no row mapper change, no behavior change for the silent-`Ok` outer wrap.

## Tests

Added `extract_from_db_skips_rows_with_null_value` — inserts one valid `composerData:` row plus one NULL-value row into the same `cursorDiskKV`, calls `extract_from_db`, asserts the valid row was extracted.

Verified locally (`cargo test -p franken-agent-detection extract_from_db_skips_rows_with_null_value`) and end-to-end through cass (`cass index --full` → `By Agent: cursor: 32`).