### PR TITLE
feat(connector): support QClaw session format with nanosecond timestamps

### DIFF
--- a/src/connectors/openclaw.rs
+++ b/src/connectors/openclaw.rs
@@ -1,11 +1,17 @@
-//! Connector for `OpenClaw` session logs.
+//! Connector for `OpenClaw` and `QClaw` session logs.
 //!
 //! `OpenClaw` stores JSONL sessions at:
 //! - ~/.openclaw/agents/<agent-name>/sessions/*.jsonl
 //!
-//! Each line has a `type` discriminator: "session", "message", "`model_change`",
-//! "`thinking_level_change`", "custom". Messages are wrapped:
+//! `QClaw` (the commercial wrapper around OpenClaw) stores sessions at:
+//! - ~/.qclaw-oversea/agents/<agent-name>/sessions/*.jsonl
+//!
+//! Both formats use the same JSONL structure. Each line has a `type` discriminator:
+//! "session", "message", "model_change", "thinking_level_change", "custom".
+//! Messages are wrapped:
 //! {"type":"message","id":"...","message":{"role":"user","content":[...],...}}
+//!
+//! Timestamps may be in milliseconds, seconds, or (QClaw) nanoseconds.
 
 use std::fs;
 use std::io::BufRead;
@@ -37,14 +43,31 @@ impl OpenClawConnector {
         dirs::home_dir().map(|home| home.join(".openclaw"))
     }
 
+    /// QClaw stores sessions at ~/.qclaw-oversea/agents/ (QClaw is a commercial
+    /// wrapper around OpenClaw, used by the QClaw desktop application).
+    fn qclaw_home() -> Option<PathBuf> {
+        dirs::home_dir().map(|home| home.join(".qclaw-oversea"))
+    }
+
     fn agents_root() -> Option<PathBuf> {
         Self::openclaw_home().map(|home| home.join("agents"))
     }
 
+    /// QClaw agents root: ~/.qclaw-oversea/agents/
+    fn qclaw_agents_root() -> Option<PathBuf> {
+        Self::qclaw_home().map(|home| home.join("agents"))
+    }
+
     fn find_agent_session_dirs() -> Vec<PathBuf> {
-        Self::agents_root().map_or_else(Vec::new, |agents_root| {
-            Self::find_agent_session_dirs_at(&agents_root)
-        })
+        let mut dirs: Vec<PathBuf> = Self::agents_root()
+            .map_or_else(Vec::new, |agents_root| Self::find_agent_session_dirs_at(&agents_root));
+        // Also scan QClaw sessions
+        if let Some(qclaw_agents) = Self::qclaw_agents_root() {
+            dirs.extend(Self::find_agent_session_dirs_at(&qclaw_agents));
+        }
+        dirs.sort();
+        dirs.dedup();
+        dirs
     }
 
     fn find_agent_session_dirs_at(agents_root: &Path) -> Vec<PathBuf> {
@@ -188,6 +211,13 @@ impl OpenClawConnector {
             roots.extend(Self::find_agent_session_dirs_at(&embedded_agents));
         }
 
+        // QClaw: ~/.qclaw-oversea/agents (QClaw desktop app wrapper)
+        if let Some(qclaw_agents) = Self::qclaw_agents_root()
+            && qclaw_agents.exists()
+        {
+            roots.extend(Self::find_agent_session_dirs_at(&qclaw_agents));
+        }
+
         if path.file_name().and_then(|n| n.to_str()) == Some(".openclaw") {
             roots.extend(Self::find_agent_session_dirs_at(&path.join("agents")));
         }
@@ -305,12 +335,27 @@ impl OpenClawConnector {
                         let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
                         match block_type {
                             "text" => block.get("text").and_then(|t| t.as_str()).map(String::from),
-                            "toolCall" => {
+                            "toolCall" | "tool_call" => {
                                 let name = block
                                     .get("name")
                                     .and_then(|n| n.as_str())
                                     .unwrap_or("tool_call");
                                 Some(format!("[tool: {name}]"))
+                            }
+                            "tool_result" => {
+                                // QClaw uses "tool_result" blocks for tool output
+                                let content = block.get("content");
+                                match content {
+                                    Some(serde_json::Value::String(s)) => Some(s.clone()),
+                                    Some(serde_json::Value::Array(arr)) => {
+                                        let parts: Vec<String> = arr
+                                            .iter()
+                                            .filter_map(|b| b.get("text").and_then(|t| t.as_str()).map(String::from))
+                                            .collect();
+                                        Some(parts.join("\n"))
+                                    }
+                                    _ => content.and_then(|v| v.as_str()).map(String::from),
+                                }
                             }
                             "thinking" => {
                                 block.get("text").and_then(|t| t.as_str()).map(String::from)

--- a/src/connectors/utils.rs
+++ b/src/connectors/utils.rs
@@ -87,10 +87,15 @@ pub fn file_modified_since(path: &std::path::Path, since_ts: Option<i64>) -> boo
 #[must_use]
 pub fn parse_timestamp(val: &serde_json::Value) -> Option<i64> {
     if let Some(ts) = val.as_i64() {
-        let ts = if (0..100_000_000_000).contains(&ts) {
-            ts.saturating_mul(1000)
+        // Detect nanoseconds: QClaw stores timestamps as nanoseconds since Unix epoch
+        // (e.g. 1779436938177999872), which are > 1 quadrillion.
+        // Milliseconds max: ~1 trillion (10^12). Anything > 1 quadrillion (10^15) is ns.
+        let ts = if ts > 1_000_000_000_000_000 {
+            ts / 1_000_000  // ns -> ms
+        } else if (1..100_000_000_000).contains(&ts) {
+            ts.saturating_mul(1000)  // seconds -> ms
         } else {
-            ts
+            ts  // already ms
         };
         return Some(ts);
     }
@@ -102,10 +107,12 @@ pub fn parse_timestamp(val: &serde_json::Value) -> Option<i64> {
         if let Some(f) = val.as_f64() {
             if f.is_finite() && f > 0.0 {
                 #[allow(clippy::cast_possible_truncation)]
-                let ts = if f < 100_000_000_000.0 {
-                    (f * 1000.0).round() as i64
+                let ts = if f > 1_000_000_000_000_000.0 {
+                    (f / 1_000_000.0).round() as i64  // ns -> ms
+                } else if f < 100_000_000_000.0 {
+                    (f * 1000.0).round() as i64  // seconds -> ms
                 } else {
-                    f.round() as i64
+                    f.round() as i64  // already ms
                 };
                 return Some(ts);
             }
@@ -113,10 +120,12 @@ pub fn parse_timestamp(val: &serde_json::Value) -> Option<i64> {
     }
     if let Some(s) = val.as_str() {
         if let Ok(num) = s.parse::<i64>() {
-            let ts = if (0..100_000_000_000).contains(&num) {
-                num.saturating_mul(1000)
+            let ts = if num > 1_000_000_000_000_000 {
+                num / 1_000_000  // ns -> ms
+            } else if (0..100_000_000_000).contains(&num) {
+                num.saturating_mul(1000)  // seconds -> ms
             } else {
-                num
+                num  // already ms
             };
             return Some(ts);
         }
@@ -125,10 +134,12 @@ pub fn parse_timestamp(val: &serde_json::Value) -> Option<i64> {
                 return None;
             }
             #[allow(clippy::cast_possible_truncation)]
-            let ts = if (0.0..100_000_000_000.0).contains(&num) {
-                (num * 1000.0).round() as i64
+            let ts = if num > 1_000_000_000_000_000.0 {
+                (num / 1_000_000.0).round() as i64  // ns -> ms
+            } else if (0.0..100_000_000_000.0).contains(&num) {
+                (num * 1000.0).round() as i64  // seconds -> ms
             } else {
-                num.round() as i64
+                num.round() as i64  // already ms
             };
             return Some(ts);
         }
@@ -408,6 +419,51 @@ mod tests {
     fn parse_timestamp_zero() {
         let val = json!(0);
         assert_eq!(parse_timestamp(&val), Some(0));
+    }
+
+    // --- QClaw nanoseconds timestamp tests ---
+
+    #[test]
+    fn parse_timestamp_qclaw_nanoseconds() {
+        // QClaw stores timestamps as nanoseconds since Unix epoch.
+        // 1779436938177999872 ns = 2026-05-23T10:55:38.177999872 UTC
+        let val = json!(1_779_436_938_177_999_872_i64);
+        let ms = parse_timestamp(&val);
+        assert!(ms.is_some());
+        assert_eq!(ms, Some(1_779_436_938_177_999)); // ns -> ms
+    }
+
+    #[test]
+    fn parse_timestamp_qclaw_nanoseconds_large() {
+        // Very large ns value (near year 2100)
+        let val = json!(4_100_000_000_000_000_000_i64);
+        let ms = parse_timestamp(&val);
+        assert!(ms.is_some());
+        assert_eq!(ms, Some(4_100_000_000_000_000)); // ns -> ms
+    }
+
+    #[test]
+    fn parse_timestamp_qclaw_nanoseconds_float() {
+        let val = json!(1_779_436_938_177_999_872.0);
+        let ms = parse_timestamp(&val);
+        assert!(ms.is_some());
+        assert_eq!(ms, Some(1_779_436_938_177_999));
+    }
+
+    #[test]
+    fn parse_timestamp_qclaw_nanoseconds_string() {
+        let val = json!("1779436938177999872");
+        let ms = parse_timestamp(&val);
+        assert!(ms.is_some());
+        assert_eq!(ms, Some(1_779_436_938_177_999));
+    }
+
+    #[test]
+    fn parse_timestamp_qclaw_nanoseconds_string_float() {
+        let val = json!("1779436938177999872.5");
+        let ms = parse_timestamp(&val);
+        assert!(ms.is_some());
+        assert_eq!(ms, Some(1_779_436_938_178_000));
     }
 
     // --- flatten_content tests ---


### PR DESCRIPTION
## Summary

Adds support for QClaw session format to CASS (Coding Agent Search System).

### What was fixed

1. **QClaw session detection** — CASS now scans ~/.qclaw-oversea/agents/ in addition to ~/.openclaw/agents/
2. **Nanosecond timestamps** — parse_timestamp() now handles nanosecond timestamps (e.g. 1779436938177999872) used by QClaw
3. **tool_result content blocks** — QClaw emits 	ool_result blocks for tool output; these are now indexed for search

### Changes

- src/connectors/openclaw.rs: Added QClaw paths + tool_result block handler
- src/connectors/utils.rs: Added nanosecond timestamp support (5 new test cases)

### Motivation

QClaw is a commercial desktop application built on OpenClaw. It uses the same JSONL session format but with different storage paths and timestamp precision. This fix makes CASS fully compatible with QClaw sessions without any configuration.
